### PR TITLE
Constrained relational operators in line with P2944R3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   UBSAN_OPTIONS: print_stacktrace=1
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   posix:

--- a/doc/variant2/reference.adoc
+++ b/doc/variant2/reference.adoc
@@ -845,6 +845,9 @@ template<class... T>
 [none]
 * {blank}
 +
+Constraints: :: `std::declval<const Ti&>() == std::declval<const Ti&>()` is a valid expression 
+  convertible to `bool` for all `Ti` in `T...`.
++
 Returns: :: `v.index() == w.index() && get<I>(v) == get<I>(w)`, where `I`
   is `v.index()`.
 
@@ -855,6 +858,9 @@ template<class... T>
 [none]
 * {blank}
 +
+Constraints: :: `std::declval<const Ti&>() != std::declval<const Ti&>()` is a valid expression 
+  convertible to `bool` for all `Ti` in `T...`.
++
 Returns: :: `!(v == w)`.
 
 ```
@@ -863,6 +869,9 @@ template<class... T>
 ```
 [none]
 * {blank}
++
+Constraints: :: `std::declval<const Ti&>() < std::declval<const Ti&>()` is a valid expression 
+  convertible to `bool` for all `Ti` in `T...`.
 +
 Returns: :: `v.index() < w.index() || (v.index() == w.index() && get<I>(v) < get<I>(w))`,
   where `I` is `v.index()`.
@@ -874,6 +883,9 @@ template<class... T>
 [none]
 * {blank}
 +
+Constraints: :: `std::declval<const Ti&>() < std::declval<const Ti&>()` is a valid expression 
+  convertible to `bool` for all `Ti` in `T...`.
++
 Returns: :: `w < v`.
 
 ```
@@ -882,6 +894,9 @@ template<class... T>
 ```
 [none]
 * {blank}
++
+Constraints: :: `std::declval<const Ti&>() \<= std::declval<const Ti&>()` is a valid expression 
+  convertible to `bool` for all `Ti` in `T...`.
 +
 Returns: :: `v.index() < w.index() || (v.index() == w.index() && get<I>(v) \<= get<I>(w))`,
   where `I` is `v.index()`.
@@ -892,6 +907,9 @@ template<class... T>
 ```
 [none]
 * {blank}
++
+Constraints: :: `std::declval<const Ti&>() \<= std::declval<const Ti&>()` is a valid expression 
+  convertible to `bool` for all `Ti` in `T...`.
 +
 Returns: ::
   `w \<= v`.

--- a/include/boost/variant2/variant.hpp
+++ b/include/boost/variant2/variant.hpp
@@ -2112,20 +2112,18 @@ namespace relops_constraints
 template<class...> struct make_void { typedef void type; };
 
 #define BOOST_VARIANT2_DEFINE_RELOP_CONSTRAINT( name, op ) \
-template<class T, class = void> struct name##_impl: std::false_type {}; \
+template<class T, class = void> struct name: std::false_type {}; \
 \
-template<class T> struct name##_impl<T, typename make_void< \
+template<class T> struct name<T, typename make_void< \
     decltype( std::declval<const T&>() op std::declval<const T&>() )>::type>: \
     std::is_convertible<decltype( std::declval<const T&>() op std::declval<const T&>() ), bool> \
 { \
-}; \
-\
-template<class T> struct name: name##_impl<T> {};
+};
 
 #else
 
-// non-expression-SFINAE fallback does not work with deleted relops, 
-// compilation fails instead, which is good enough
+// non-expression-SFINAE fallback does not work with deleted relops: 
+// variant's relop instantiation fails instead, which is good enough
 
 struct not_comparable {};
 template<class U> not_comparable operator==( U const &, U const & );

--- a/include/boost/variant2/variant.hpp
+++ b/include/boost/variant2/variant.hpp
@@ -2103,6 +2103,21 @@ public:
 namespace detail
 {
 
+namespace relops_constraints
+{
+
+struct not_comparable {};
+template<class U> not_comparable operator==( U const &, U const & );
+template<class U> not_comparable operator!=( U const &, U const & );
+template<class U> not_comparable operator< ( U const &, U const & );
+template<class U> not_comparable operator<=( U const &, U const & );
+
+template<class T> struct has_eq: std::is_convertible<decltype( std::declval<const T&>() == std::declval<const T&>() ), bool>
+{
+};
+
+} // namespace relops_constraints
+
 template<class... T> struct eq_L
 {
     variant<T...> const & v;
@@ -2116,13 +2131,23 @@ template<class... T> struct eq_L
 
 } // namespace detail
 
-template<class... T> constexpr bool operator==( variant<T...> const & v, variant<T...> const & w )
+template<class... T,  class E = typename std::enable_if<mp11::mp_all<detail::relops_constraints::has_eq<T>...>::value>::type>
+constexpr bool operator==( variant<T...> const & v, variant<T...> const & w )
 {
     return v.index() == w.index() && mp11::mp_with_index<sizeof...(T)>( v.index(), detail::eq_L<T...>{ v, w } );
 }
 
 namespace detail
 {
+
+namespace relops_constraints
+{
+
+template<class T> struct has_neq: std::is_convertible<decltype( std::declval<const T&>() != std::declval<const T&>() ), bool>
+{
+};
+
+} // namespace relops_constraints
 
 template<class... T> struct ne_L
 {
@@ -2137,13 +2162,23 @@ template<class... T> struct ne_L
 
 } // namespace detail
 
-template<class... T> constexpr bool operator!=( variant<T...> const & v, variant<T...> const & w )
+template<class... T,  class E = typename std::enable_if<mp11::mp_all<detail::relops_constraints::has_neq<T>...>::value>::type>
+constexpr bool operator!=( variant<T...> const & v, variant<T...> const & w )
 {
     return v.index() != w.index() || mp11::mp_with_index<sizeof...(T)>( v.index(), detail::ne_L<T...>{ v, w } );
 }
 
 namespace detail
 {
+
+namespace relops_constraints
+{
+
+template<class T> struct has_lt: std::is_convertible<decltype( std::declval<const T&>() < std::declval<const T&>() ), bool>
+{
+};
+
+} // namespace relops_constraints
 
 template<class... T> struct lt_L
 {
@@ -2158,18 +2193,29 @@ template<class... T> struct lt_L
 
 } // namespace detail
 
-template<class... T> constexpr bool operator<( variant<T...> const & v, variant<T...> const & w )
+template<class... T,  class E = typename std::enable_if<mp11::mp_all<detail::relops_constraints::has_lt<T>...>::value>::type>
+constexpr bool operator<( variant<T...> const & v, variant<T...> const & w )
 {
     return v.index() < w.index() || ( v.index() == w.index() && mp11::mp_with_index<sizeof...(T)>( v.index(), detail::lt_L<T...>{ v, w } ) );
 }
 
-template<class... T> constexpr bool operator>(  variant<T...> const & v, variant<T...> const & w )
+template<class... T,  class E = typename std::enable_if<mp11::mp_all<detail::relops_constraints::has_lt<T>...>::value>::type>
+constexpr bool operator>(  variant<T...> const & v, variant<T...> const & w )
 {
     return w < v;
 }
 
 namespace detail
 {
+
+namespace relops_constraints
+{
+
+template<class T> struct has_le: std::is_convertible<decltype( std::declval<const T&>() <= std::declval<const T&>() ), bool>
+{
+};
+
+} // namespace relops_constraints
 
 template<class... T> struct le_L
 {
@@ -2184,12 +2230,14 @@ template<class... T> struct le_L
 
 } // namespace detail
 
-template<class... T> constexpr bool operator<=( variant<T...> const & v, variant<T...> const & w )
+template<class... T,  class E = typename std::enable_if<mp11::mp_all<detail::relops_constraints::has_le<T>...>::value>::type>
+constexpr bool operator<=( variant<T...> const & v, variant<T...> const & w )
 {
     return v.index() < w.index() || ( v.index() == w.index() && mp11::mp_with_index<sizeof...(T)>( v.index(), detail::le_L<T...>{ v, w } ) );
 }
 
-template<class... T> constexpr bool operator>=( variant<T...> const & v, variant<T...> const & w )
+template<class... T,  class E = typename std::enable_if<mp11::mp_all<detail::relops_constraints::has_le<T>...>::value>::type>
+constexpr bool operator>=( variant<T...> const & v, variant<T...> const & w )
 {
     return w <= v;
 }

--- a/include/boost/variant2/variant.hpp
+++ b/include/boost/variant2/variant.hpp
@@ -2106,15 +2106,41 @@ namespace detail
 namespace relops_constraints
 {
 
+#if !defined(BOOST_NO_SFINAE_EXPR) && \
+    !BOOST_WORKAROUND(BOOST_MSVC, < 1900) && !BOOST_WORKAROUND(BOOST_GCC, < 40900)
+
+template<class...> struct make_void { typedef void type; };
+
+#define BOOST_VARIANT2_DEFINE_RELOP_CONSTRAINT( name, op ) \
+template<class T, class = void> struct name##_impl: std::false_type {}; \
+\
+template<class T> struct name##_impl<T, typename make_void< \
+    decltype( std::declval<const T&>() op std::declval<const T&>() )>::type>: \
+    std::is_convertible<decltype( std::declval<const T&>() op std::declval<const T&>() ), bool> \
+{ \
+}; \
+\
+template<class T> struct name: name##_impl<T> {};
+
+#else
+
+// non-expression-SFINAE fallback does not work with deleted relops, 
+// compilation fails instead, which is good enough
+
 struct not_comparable {};
 template<class U> not_comparable operator==( U const &, U const & );
 template<class U> not_comparable operator!=( U const &, U const & );
 template<class U> not_comparable operator< ( U const &, U const & );
 template<class U> not_comparable operator<=( U const &, U const & );
 
-template<class T> struct has_eq: std::is_convertible<decltype( std::declval<const T&>() == std::declval<const T&>() ), bool>
-{
+#define BOOST_VARIANT2_DEFINE_RELOP_CONSTRAINT( name, op ) \
+template<class T> struct name: std::is_convertible<decltype( std::declval<const T&>() op std::declval<const T&>() ), bool> \
+{ \
 };
+
+#endif
+
+BOOST_VARIANT2_DEFINE_RELOP_CONSTRAINT( has_eq, == )
 
 } // namespace relops_constraints
 
@@ -2143,9 +2169,7 @@ namespace detail
 namespace relops_constraints
 {
 
-template<class T> struct has_neq: std::is_convertible<decltype( std::declval<const T&>() != std::declval<const T&>() ), bool>
-{
-};
+BOOST_VARIANT2_DEFINE_RELOP_CONSTRAINT( has_ne, != )
 
 } // namespace relops_constraints
 
@@ -2162,7 +2186,7 @@ template<class... T> struct ne_L
 
 } // namespace detail
 
-template<class... T,  class E = typename std::enable_if<mp11::mp_all<detail::relops_constraints::has_neq<T>...>::value>::type>
+template<class... T,  class E = typename std::enable_if<mp11::mp_all<detail::relops_constraints::has_ne<T>...>::value>::type>
 constexpr bool operator!=( variant<T...> const & v, variant<T...> const & w )
 {
     return v.index() != w.index() || mp11::mp_with_index<sizeof...(T)>( v.index(), detail::ne_L<T...>{ v, w } );
@@ -2174,9 +2198,7 @@ namespace detail
 namespace relops_constraints
 {
 
-template<class T> struct has_lt: std::is_convertible<decltype( std::declval<const T&>() < std::declval<const T&>() ), bool>
-{
-};
+BOOST_VARIANT2_DEFINE_RELOP_CONSTRAINT( has_lt, < )
 
 } // namespace relops_constraints
 
@@ -2211,9 +2233,8 @@ namespace detail
 namespace relops_constraints
 {
 
-template<class T> struct has_le: std::is_convertible<decltype( std::declval<const T&>() <= std::declval<const T&>() ), bool>
-{
-};
+BOOST_VARIANT2_DEFINE_RELOP_CONSTRAINT( has_le, <= )
+#undef BOOST_VARIANT2_DEFINE_RELOP_CONSTRAINT
 
 } // namespace relops_constraints
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -180,3 +180,5 @@ run variant_issue_55.cpp
     # clang-cl 32 bit fails with an assertion in mp_with_index, likely due to a codegen bug
     "<toolset>clang-win,<address-model>32:<build>no"
   ;
+
+run variant_constrained_relops.cpp ;

--- a/test/variant_constrained_relops.cpp
+++ b/test/variant_constrained_relops.cpp
@@ -9,6 +9,7 @@
 #include <boost/variant2/variant.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <boost/core/lightweight_test_trait.hpp>
+#include <functional>
 #include <type_traits>
 
 #if !defined(BOOST_NO_SFINAE_EXPR) && \
@@ -99,6 +100,15 @@ struct bad_le
     void operator<=( const bad_le& ) const;
 };
 
+struct non_comparable {};
+
+template<typename T>
+struct wrapper
+{ 
+    T t; 
+    bool operator<(const wrapper& x) const { return t < x.t; }; 
+};
+
 int main()
 {
     {
@@ -187,6 +197,16 @@ int main()
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), not_found>));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), bool     >));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >= std::declval<v_t>() ), not_found>));
+    }
+
+    {
+        //https://github.com/boostorg/variant2/issues/60
+
+        using v_t = variant<non_comparable>;
+        using reference_wrapper = std::reference_wrapper<v_t>;
+
+        wrapper<reference_wrapper*> x{nullptr}, y{nullptr};
+        (void)(x < y);
     }
 
     return boost::report_errors();

--- a/test/variant_constrained_relops.cpp
+++ b/test/variant_constrained_relops.cpp
@@ -11,6 +11,11 @@
 #include <boost/core/lightweight_test_trait.hpp>
 #include <type_traits>
 
+#if !defined(BOOST_NO_SFINAE_EXPR) && \
+    !BOOST_WORKAROUND(BOOST_MSVC, < 1900) && !BOOST_WORKAROUND(BOOST_GCC, < 40900)
+#define USE_DELETED_RELOPS
+#endif
+
 using namespace boost::variant2;
 
 struct not_found {};
@@ -24,6 +29,9 @@ not_found operator>=( any const &, any const & );
 
 struct no_eq
 {
+#ifdef USE_DELETED_RELOPS
+    bool operator==( const no_eq& ) const = delete;
+#endif
     int  operator!=( const no_eq& ) const;
     int  operator< ( const no_eq& ) const;
     int  operator<=( const no_eq& ) const;
@@ -37,25 +45,31 @@ struct bad_eq
     int  operator<=( const bad_eq& ) const;
 };
 
-struct no_neq
+struct no_ne
 {
-    int  operator==( const no_neq& ) const;
-    int  operator< ( const no_neq& ) const;
-    int  operator<=( const no_neq& ) const;
+    int  operator==( const no_ne& ) const;
+#ifdef USE_DELETED_RELOPS
+    bool operator!=( const no_ne& ) const = delete;
+#endif
+    int  operator< ( const no_ne& ) const;
+    int  operator<=( const no_ne& ) const;
 };
 
-struct bad_neq
+struct bad_ne
 {
-    int  operator==( const bad_neq& ) const;
-    void operator!=( const bad_neq& ) const;
-    int  operator< ( const bad_neq& ) const;
-    int  operator<=( const bad_neq& ) const;
+    int  operator==( const bad_ne& ) const;
+    void operator!=( const bad_ne& ) const;
+    int  operator< ( const bad_ne& ) const;
+    int  operator<=( const bad_ne& ) const;
 };
 
 struct no_lt
 {
     int  operator==( const no_lt& ) const;
     int  operator!=( const no_lt& ) const;
+#ifdef USE_DELETED_RELOPS
+    bool operator< ( const no_lt& ) const = delete;
+#endif
     int  operator<=( const no_lt& ) const;
 };
 
@@ -72,6 +86,9 @@ struct no_le
     int  operator==( const no_le& ) const;
     int  operator!=( const no_le& ) const;
     int  operator< ( const no_le& ) const;
+#ifdef USE_DELETED_RELOPS
+    bool operator<=( const no_le& ) const = delete;
+#endif
 };
 
 struct bad_le
@@ -107,7 +124,7 @@ int main()
     }
 
     {
-        using v_t = const variant<int, no_neq>&;
+        using v_t = const variant<int, no_ne>&;
 
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), not_found>));
@@ -118,7 +135,7 @@ int main()
     }
 
     {
-        using v_t = const variant<int, bad_neq>&;
+        using v_t = const variant<int, bad_ne>&;
 
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), not_found>));

--- a/test/variant_constrained_relops.cpp
+++ b/test/variant_constrained_relops.cpp
@@ -1,0 +1,176 @@
+
+// Copyright 2026 Joaquin M Lopez Munoz.
+//
+// Distributed under the Boost Software License, Version 1.0.
+//
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/variant2/variant.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <boost/core/lightweight_test_trait.hpp>
+#include <type_traits>
+
+using namespace boost::variant2;
+
+struct not_found {};
+struct any { any( ... ); };
+not_found operator==( any const &, any const & );
+not_found operator!=( any const &, any const & );
+not_found operator< ( any const &, any const & );
+not_found operator<=( any const &, any const & );
+not_found operator> ( any const &, any const & );
+not_found operator>=( any const &, any const & );
+
+struct no_eq
+{
+    int  operator!=( const no_eq& ) const;
+    int  operator< ( const no_eq& ) const;
+    int  operator<=( const no_eq& ) const;
+};
+
+struct bad_eq
+{
+    void operator==( const bad_eq& ) const;
+    int  operator!=( const bad_eq& ) const;
+    int  operator< ( const bad_eq& ) const;
+    int  operator<=( const bad_eq& ) const;
+};
+
+struct no_neq
+{
+    int  operator==( const no_neq& ) const;
+    int  operator< ( const no_neq& ) const;
+    int  operator<=( const no_neq& ) const;
+};
+
+struct bad_neq
+{
+    int  operator==( const bad_neq& ) const;
+    void operator!=( const bad_neq& ) const;
+    int  operator< ( const bad_neq& ) const;
+    int  operator<=( const bad_neq& ) const;
+};
+
+struct no_lt
+{
+    int  operator==( const no_lt& ) const;
+    int  operator!=( const no_lt& ) const;
+    int  operator<=( const no_lt& ) const;
+};
+
+struct bad_lt
+{
+    int  operator==( const bad_lt& ) const;
+    int  operator!=( const bad_lt& ) const;
+    void operator< ( const bad_lt& ) const;
+    int  operator<=( const bad_lt& ) const;
+};
+
+struct no_le
+{
+    int  operator==( const no_le& ) const;
+    int  operator!=( const no_le& ) const;
+    int  operator< ( const no_le& ) const;
+};
+
+struct bad_le
+{
+    int  operator==( const bad_le& ) const;
+    int  operator!=( const bad_le& ) const;
+    int  operator< ( const bad_le& ) const;
+    void operator<=( const bad_le& ) const;
+};
+
+int main()
+{
+    {
+        using v_t = const variant<int, no_eq>&;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >= std::declval<v_t>() ), bool     >));
+    }
+
+    {
+        using v_t = const variant<int, bad_eq>&;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >= std::declval<v_t>() ), bool     >));
+    }
+
+    {
+        using v_t = const variant<int, no_neq>&;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >= std::declval<v_t>() ), bool     >));
+    }
+
+    {
+        using v_t = const variant<int, bad_neq>&;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >= std::declval<v_t>() ), bool     >));
+    }
+
+    {
+        using v_t = const variant<int, no_lt>&;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >= std::declval<v_t>() ), bool     >));
+    }
+
+    {
+        using v_t = const variant<int, bad_lt>&;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >= std::declval<v_t>() ), bool     >));
+    }
+
+    {
+        using v_t = const variant<int, no_le>&;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >= std::declval<v_t>() ), not_found>));
+    }
+
+    {
+        using v_t = const variant<int, bad_le>&;
+
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), bool     >));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >= std::declval<v_t>() ), not_found>));
+    }
+
+    return boost::report_errors();
+}

--- a/test/variant_constrained_relops.cpp
+++ b/test/variant_constrained_relops.cpp
@@ -20,13 +20,13 @@
 using namespace boost::variant2;
 
 struct not_found {};
-struct any { any( ... ); };
-not_found operator==( any const &, any const & );
-not_found operator!=( any const &, any const & );
-not_found operator< ( any const &, any const & );
-not_found operator<=( any const &, any const & );
-not_found operator> ( any const &, any const & );
-not_found operator>=( any const &, any const & );
+struct variant_sink { template<class... T> variant_sink( variant<T...> const & ); };
+not_found operator==( variant_sink const &, variant_sink const & );
+not_found operator!=( variant_sink const &, variant_sink const & );
+not_found operator< ( variant_sink const &, variant_sink const & );
+not_found operator<=( variant_sink const &, variant_sink const & );
+not_found operator> ( variant_sink const &, variant_sink const & );
+not_found operator>=( variant_sink const &, variant_sink const & );
 
 struct no_eq
 {

--- a/test/variant_constrained_relops.cpp
+++ b/test/variant_constrained_relops.cpp
@@ -127,7 +127,7 @@ int main()
         using v_t = const variant<int, no_ne>&;
 
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
-        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( operator!=( std::declval<v_t>(), std::declval<v_t>() ) ), not_found>));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), bool     >));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), bool     >));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), bool     >));
@@ -138,7 +138,7 @@ int main()
         using v_t = const variant<int, bad_ne>&;
 
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
-        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() != std::declval<v_t>() ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( operator!= ( std::declval<v_t>(), std::declval<v_t>() ) ), not_found>));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), bool     >));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), bool     >));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), bool     >));

--- a/test/variant_constrained_relops.cpp
+++ b/test/variant_constrained_relops.cpp
@@ -148,7 +148,7 @@ int main()
         using v_t = const variant<int, bad_ne>&;
 
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() == std::declval<v_t>() ), bool     >));
-        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( operator!= ( std::declval<v_t>(), std::declval<v_t>() ) ), not_found>));
+        BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( operator!=( std::declval<v_t>(), std::declval<v_t>() ) ), not_found>));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <  std::declval<v_t>() ), bool     >));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() <= std::declval<v_t>() ), bool     >));
         BOOST_TEST_TRAIT_TRUE((std::is_same<decltype( std::declval<v_t>() >  std::declval<v_t>() ), bool     >));


### PR DESCRIPTION
Closes #60. Observations:

* The constraints are not 1:1 with those of `std::variant` because Boost.Variant2 implements `operator>`/`operator>=` in terms of `operator<`/`operator<=`.
* For compilers without expression SFINAE support, constraint checking does not work if any of the corresponding `Ti`'s relops is deleted: in this case, `variant`'s relop fails to instantiate (as before this PR). This limitation is not documented in the reference.